### PR TITLE
Force keep xcmonkey in the target app

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gem 'xcmonkey'
 ### To run a stress test
 
 ```bash
-xcmonkey test --udid "413EA256-CFFB-4312-94A6-12592BEE4CBA" --bundle-id "com.apple.Maps" --duration 100
+$ xcmonkey test --duration 100 --bundle-id "com.apple.Maps" --udid "413EA256-CFFB-4312-94A6-12592BEE4CBA"
 
 12:44:19.343: Device info: {
   "name": "iPhone 14 Pro",
@@ -106,9 +106,9 @@ require 'xcmonkey'
 
 lane :test do
   Xcmonkey.new(
-    udid: '413EA256-CFFB-4312-94A6-12592BEE4CBA',
+    duration: 100,
     bundle_id: 'com.apple.Maps',
-    duration: 100
+    udid: '413EA256-CFFB-4312-94A6-12592BEE4CBA'
   ).run
 end
 ```

--- a/spec/describer_spec.rb
+++ b/spec/describer_spec.rb
@@ -2,15 +2,17 @@ describe Describer do
   let(:udid) { `xcrun simctl list | grep " iPhone 14 Pro Max"`.split("\n")[0].split('(')[1].split(')')[0] }
   let(:driver) { Driver.new(udid: udid) }
 
-  it 'verifies that point can be described (integer)' do
+  before do
     allow(Logger).to receive(:info)
+  end
+
+  it 'verifies that point can be described (integer)' do
     driver.boot_simulator
     point_info = described_class.new(udid: udid, x: 10, y: 10).run
     expect(point_info).not_to be_empty
   end
 
   it 'verifies that point can be described (string)' do
-    allow(Logger).to receive(:info)
     driver.boot_simulator
     point_info = described_class.new(udid: udid, x: '10', y: '10').run
     expect(point_info).not_to be_empty

--- a/spec/xcmonkey_spec.rb
+++ b/spec/xcmonkey_spec.rb
@@ -2,6 +2,10 @@ describe Xcmonkey do
   let(:params) { { udid: '123', bundle_id: 'example.com.app', duration: 10, session_path: Dir.pwd } }
   let(:duration_error_msg) { 'Duration must be Integer and not less than 1 second' }
 
+  before do
+    allow(Logger).to receive(:info)
+  end
+
   it 'verifies gestures' do
     gestures = described_class.new(params).gestures
     taps = [:precise_tap, :blind_tap] * 10


### PR DESCRIPTION
# Changes

## References

- https://github.com/alteral/xcmonkey/issues/5

## Description

- There are multiple ways the user can leave the app (go to the background, browser, third-party app, etc). That's why it'd be great to force keep xcmonkey in the target app.

## Risks

- [ ] None
- [ ] Low
- [x] High
